### PR TITLE
Fix inverted A estimate in get_kalman_ho_estimates (Kalman-Ho)

### DIFF
--- a/xfads/prob_utils.py
+++ b/xfads/prob_utils.py
@@ -205,10 +205,13 @@ def get_kalman_ho_estimates(H, Gamma_0, n_neurons, n_latents):
     C_hat = obs_matrix[:n_neurons, :]
     B_hat = ctr_matrix[:n_latents, :]  # B_hat ≈ B, not P_inf
 
-    # Estimate A using shifted observability matrices
+    # Estimate A using shift-invariance of the observability matrix.
+    # obs_matrix_top drops the last block row, obs_matrix_bot the first, so
+    # obs_matrix_bot = obs_matrix_top @ A. Solve this least-squares system for A
+    # (solving the reverse yields A^{-1}: reciprocal eigenvalues / reversed rotation).
     obs_matrix_top = obs_matrix[:-n_neurons, :]
     obs_matrix_bot = obs_matrix[n_neurons:, :]
-    A_hat = torch.linalg.pinv(obs_matrix_bot) @ obs_matrix_top
+    A_hat = torch.linalg.lstsq(obs_matrix_top, obs_matrix_bot).solution
 
     # Estimate Q from B: Q_hat = B B^T
     Q_hat = B_hat @ B_hat.T


### PR DESCRIPTION
## Problem

`get_kalman_ho_estimates` solves the observability shift-invariance relation the wrong way when estimating the state-transition matrix `A`:

```python
A_hat = torch.linalg.pinv(obs_matrix_bot) @ obs_matrix_top
```

With `obs_matrix_top` dropping the last block row and `obs_matrix_bot` the first, shift-invariance gives `obs_matrix_bot = obs_matrix_top @ A`. Solving it as written returns **A⁻¹**, not `A`: the eigenvalues come out as reciprocals. For near-unit-circle (rotational) dynamics the magnitudes look approximately right but the rotation direction is reversed, which is likely why it went unnoticed.

## Fix

Solve the correct least-squares system `A = argmin ||obs_top @ A - obs_bot||` with `torch.linalg.lstsq` (consistent with `align_latent_variables` elsewhere in this file, and preferable to forming the pseudoinverse explicitly):

```python
A_hat = torch.linalg.lstsq(obs_matrix_top, obs_matrix_bot).solution
```

## Verification

Synthetic LDS with `A = 0.9 · R(0.35)` (so `|eig(A)| = 0.9`), 6 outputs, 20k steps:

| | `|eig(Â)|` |
|---|---|
| before | ~1.09 (≈ `|eig(A⁻¹)|` = 1.11) |
| after | ~0.915 (≈ 0.9) |

Note: the accompanying workshop notebook (`01_latent_variable_models`, "Kalman-Ho" Step 4 markdown) documents the same inverted formula and should be updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)