### PR TITLE
Fix dynamics_type comparison (use == not is; raise on unknown)

### DIFF
--- a/xfads/ssm_modules/prebuilt_models.py
+++ b/xfads/ssm_modules/prebuilt_models.py
@@ -44,14 +44,14 @@ def create_xfads_poisson_log_link(cfg, n_neurons_obs, train_dataloader, model_ty
     Q_diag = 1. * torch.ones(cfg.n_latents, device=cfg.device)
     dynamics_fn = utils.build_gru_dynamics_function(cfg.n_latents, cfg.n_hidden_dynamics, device=cfg.device)
 
-    if dynamics_type is 'nonlinear':
+    if dynamics_type == 'nonlinear':
         dynamics_fn = utils.build_gru_dynamics_function(cfg.n_latents, cfg.n_hidden_dynamics, device=cfg.device)
 
-    elif dynamics_type is 'diffusion':
+    elif dynamics_type == 'diffusion':
         dynamics_fn = utils.DynamicsEye()
 
     else:
-        sys.exit('not a supported "dynamics_type"')
+        raise ValueError(f"unsupported dynamics_type: {dynamics_type!r}")
 
     dynamics_mod = DenseGaussianDynamics(dynamics_fn, cfg.n_latents, Q_diag, device=cfg.device)
 
@@ -94,14 +94,14 @@ def create_xfads_poisson_log_link_w_input(cfg, n_neurons_obs, n_inputs, train_da
     """dynamics module"""
     Q_diag = 1. * torch.ones(cfg.n_latents, device=cfg.device)
 
-    if dynamics_type is 'nonlinear':
+    if dynamics_type == 'nonlinear':
         dynamics_fn = utils.build_gru_dynamics_function(cfg.n_latents, cfg.n_hidden_dynamics,
                                                         device=cfg.device, use_layer_norm=cfg.use_layer_norm)
-    elif dynamics_type is 'diffusion':
+    elif dynamics_type == 'diffusion':
         dynamics_fn = utils.DynamicsEye()
 
     else:
-        sys.exit('not a supported "dynamics_type"')
+        raise ValueError(f"unsupported dynamics_type: {dynamics_type!r}")
 
     dynamics_mod = DenseGaussianDynamics(dynamics_fn, cfg.n_latents, Q_diag, device=cfg.device)
 


### PR DESCRIPTION
### Problem
`create_xfads_poisson_log_link` and `create_xfads_poisson_log_link_w_input` select the prior dynamics with `dynamics_type is 'nonlinear'` / `is 'diffusion'`. `is` compares object **identity**, not value — it only works here because CPython interns those string literals. A `dynamics_type` that arrives as a **non-interned** string (read from a YAML/config, argparse, or built at runtime like `f"{x}"`) can compare `False`, silently skip both branches, and hit the `else`, which calls `sys.exit(...)` — terminating the caller's entire process rather than raising a catchable error. Python also emits a `SyntaxWarning: "is" with a literal`.

### Fix
- `is` → `==` for the four `dynamics_type` comparisons (both prebuilt functions).
- `sys.exit('not a supported "dynamics_type"')` → `raise ValueError(f"unsupported dynamics_type: {dynamics_type!r}")` so an unknown value is a normal, catchable exception naming the offending value.

Purely a correctness fix; no API or behavior change for the supported `'nonlinear'` / `'diffusion'` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)