### PR TITLE
Add dynamics_type='linear' and a smooth() convenience method

### DIFF
--- a/xfads/smoothers/nonlinear_smoother.py
+++ b/xfads/smoothers/nonlinear_smoother.py
@@ -39,6 +39,16 @@ class LowRankNonlinearStateSpaceModel(nn.Module):
         loss = loss.sum(dim=-1).mean()
         return loss, z_s, stats
 
+    @torch.no_grad()
+    def smooth(self, y, n_samples: int = 25):
+        """Posterior-mean smoothed latent trajectories.
+
+        Convenience wrapper so users do not have to call the model and reach into
+        the stats dict. Returns m_f of shape (n_trials, n_time_bins, n_latents).
+        """
+        _, _, stats = self(y, n_samples)
+        return stats['m_f']
+
     def fast_filter_1_to_T(self,
                            y,
                            n_samples: int,

--- a/xfads/ssm_modules/prebuilt_models.py
+++ b/xfads/ssm_modules/prebuilt_models.py
@@ -47,6 +47,9 @@ def create_xfads_poisson_log_link(cfg, n_neurons_obs, train_dataloader, model_ty
     if dynamics_type == 'nonlinear':
         dynamics_fn = utils.build_gru_dynamics_function(cfg.n_latents, cfg.n_hidden_dynamics, device=cfg.device)
 
+    elif dynamics_type == 'linear':
+        dynamics_fn = utils.DynamicsLinear(cfg.n_latents, device=cfg.device)
+
     elif dynamics_type == 'diffusion':
         dynamics_fn = utils.DynamicsEye()
 
@@ -97,6 +100,9 @@ def create_xfads_poisson_log_link_w_input(cfg, n_neurons_obs, n_inputs, train_da
     if dynamics_type == 'nonlinear':
         dynamics_fn = utils.build_gru_dynamics_function(cfg.n_latents, cfg.n_hidden_dynamics,
                                                         device=cfg.device, use_layer_norm=cfg.use_layer_norm)
+    elif dynamics_type == 'linear':
+        dynamics_fn = utils.DynamicsLinear(cfg.n_latents, device=cfg.device)
+
     elif dynamics_type == 'diffusion':
         dynamics_fn = utils.DynamicsEye()
 

--- a/xfads/utils.py
+++ b/xfads/utils.py
@@ -64,6 +64,17 @@ class DynamicsEye(torch.nn.Module):
         return z
 
 
+class DynamicsLinear(torch.nn.Module):
+    """Linear prior dynamics z_t = A z_{t-1} (no bias). The natural middle rung
+    between fixed identity (DynamicsEye) and a nonlinear GRU flow."""
+    def __init__(self, latent_dim, device='cpu'):
+        super(DynamicsLinear, self).__init__()
+        self.A = nn.Linear(latent_dim, latent_dim, bias=False, device=device)
+
+    def forward(self, z):
+        return self.A(z)
+
+
 class DynamicsQuadSaddle(torch.nn.Module):
     def __init__(self, device):
         super(DynamicsQuadSaddle, self).__init__()


### PR DESCRIPTION
Two small, additive usability improvements for the prebuilt Poisson interface. **Stacked on #23** (base is that branch so the diff shows only these additions; GitHub will retarget to `main` once #23 merges).

### 1. `dynamics_type='linear'`
`create_xfads_poisson_log_link` / `..._w_input` currently offer only `'nonlinear'` (GRU) and `'diffusion'` (fixed identity), so the natural middle rung — a learned linear map — has to be built by hand. This adds `utils.DynamicsLinear` (a bias-free `z_t = A z_{t-1}`) and wires it in as `dynamics_type='linear'`, making the `identity -> linear -> nonlinear` complexity ladder a one-argument choice.

### 2. `LowRankNonlinearStateSpaceModel.smooth(y, n_samples)`
Returns the posterior-mean smoothed latents `m_f` of shape `(n_trials, n_time_bins, n_latents)` directly, so users don't have to call the model and reach into `stats['m_f']`:
```python
z = ssm.smooth(y)          # instead of: _, _, stats = ssm(y, n); z = stats['m_f']
```

Both are purely additive — existing `'nonlinear'`/`'diffusion'` behavior is unchanged. Verified: all three `dynamics_type` values build and `smooth()` returns the expected shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)