### PR TITLE
Fix transpose in align_latent_variables

### DIFF
--- a/xfads/prob_utils.py
+++ b/xfads/prob_utils.py
@@ -126,13 +126,22 @@ def kalman_information_filter(k, K, F, Q_diag, m_0, Q_0_diag):
 
 
 def align_latent_variables(z_1, z_2):
-    # align z_2 onto z_1
+    # Align z_2 onto z_1 by regressing z_1 on z_2. A linear latent model is
+    # identifiable only up to an invertible linear map, so we undo that
+    # ambiguity (rotation, scale, reflection) with a least-squares fit.
+    #
+    # lstsq(z_2, z_1) returns W minimizing || z_2 @ W - z_1 ||, so the aligned
+    # estimate is z_2 @ W. Per time point z_2 is a row vector v, and
+    # v @ W == W^T @ v (as a column vector), hence bmv uses W.mT (= W^T).
+    # Using W directly here would apply the transpose map: harmless for a pure
+    # reflection/scaling (W diagonal, W == W^T) but wrong whenever the fit is a
+    # genuine rotation (off-diagonal W), where it applies the inverse rotation.
 
     B, T, L = z_1.shape
     z_1_reshaped = z_1.reshape(B * T, L)
     z_2_reshaped = z_2.reshape(B * T, L)
     lstsq_sol = torch.linalg.lstsq(z_2_reshaped, z_1_reshaped)
-    z_2_rot = bmv(lstsq_sol.solution, z_2)
+    z_2_rot = bmv(lstsq_sol.solution.mT, z_2)
 
     return lstsq_sol.solution, z_2_rot
 

--- a/xfads/prob_utils.py
+++ b/xfads/prob_utils.py
@@ -132,18 +132,24 @@ def align_latent_variables(z_1, z_2):
     #
     # lstsq(z_2, z_1) returns W minimizing || z_2 @ W - z_1 ||, so the aligned
     # estimate is z_2 @ W. Per time point z_2 is a row vector v, and
-    # v @ W == W^T @ v (as a column vector), hence bmv uses W.mT (= W^T).
-    # Using W directly here would apply the transpose map: harmless for a pure
-    # reflection/scaling (W diagonal, W == W^T) but wrong whenever the fit is a
-    # genuine rotation (off-diagonal W), where it applies the inverse rotation.
+    # v @ W == W^T @ v (as a column vector), so applying the map with bmv (which
+    # left-multiplies) needs W^T. Using W directly would apply the transpose map:
+    # harmless for a pure reflection/scaling (W diagonal, W == W^T) but wrong
+    # whenever the fit is a genuine rotation (off-diagonal W), where it applies
+    # the inverse rotation.
+    #
+    # We return W^T (the bmv-ready map) so a caller can align other latents the
+    # same way, e.g. bmv(rot, z_samples); returning the raw lstsq solution would
+    # make those bmv calls apply the transpose (buggy) map.
 
     B, T, L = z_1.shape
     z_1_reshaped = z_1.reshape(B * T, L)
     z_2_reshaped = z_2.reshape(B * T, L)
     lstsq_sol = torch.linalg.lstsq(z_2_reshaped, z_1_reshaped)
-    z_2_rot = bmv(lstsq_sol.solution.mT, z_2)
+    rot = lstsq_sol.solution.mT
+    z_2_rot = bmv(rot, z_2)
 
-    return lstsq_sol.solution, z_2_rot
+    return rot, z_2_rot
 
 
 def construct_hankel(y_batch, m, k):


### PR DESCRIPTION
lstsq(z_2, z_1) returns W minimizing ||z_2 @ W - z_1||, so the aligned estimate is z_2 @ W. Per time point z_2 is a row vector v, and v @ W == W^T @ v as a column vector, so the bmv call must use W.mT (= W^T).

The previous code applied bmv(W, z_2) = W @ z_2, i.e. the transpose of the intended map.

- Harmless for a pure reflection/scaling: W is diagonal, so W == W^T.
- Wrong for a genuine rotation: off-diagonal W means the code applies the inverse rotation, leaving the aligned latent misrotated (and often looking sign-flipped on one component).

## Repro
With a true 90-deg rotation between z_2 and z_1, applying W gives MSE ~4.44 vs the truth, while applying W.mT gives ~1e-4.

## Change
- Apply `lstsq_sol.solution.mT` in the `bmv`.
- Add comments documenting the least-squares convention and why the transpose is needed.

Only affects the `align_latent_variables` diagnostic helper; no library internals call it (only the lvm_progression demo notebook does).