### PR TITLE
Document the m_f key in the nonlinear smoother

### DIFF
--- a/xfads/smoothers/nonlinear_smoother.py
+++ b/xfads/smoothers/nonlinear_smoother.py
@@ -349,6 +349,12 @@ class NonlinearFilter(nn.Module):
             z_f.append(z_f_t)
 
         z_f = torch.stack(z_f, dim=2)
+        # m_f: posterior-mean latent state per time step, (n_trials, n_time_bins,
+        # n_latents). It is the *filtered* mean when reached via
+        # fast_filter_1_to_T (local encoder only) and the *smoothed* mean via
+        # fast_smooth_1_to_T (adds the backward encoder, conditioning on the whole
+        # trial). Sample-based, so it is stochastic across calls; n_samples trades
+        # variance for cost. (The 'm_f' name is legacy filter notation.)
         stats['m_f'] = torch.stack(m_f, dim=1)
 
         if get_kl:
@@ -406,6 +412,12 @@ class NonlinearFilterSmallL(nn.Module):
             P_p_chol.append(P_p_chol_t)
 
         z_f = torch.stack(z_f, dim=2)
+        # m_f: posterior-mean latent state per time step, (n_trials, n_time_bins,
+        # n_latents). It is the *filtered* mean when reached via
+        # fast_filter_1_to_T (local encoder only) and the *smoothed* mean via
+        # fast_smooth_1_to_T (adds the backward encoder, conditioning on the whole
+        # trial). Sample-based, so it is stochastic across calls; n_samples trades
+        # variance for cost. (The 'm_f' name is legacy filter notation.)
         stats['m_f'] = torch.stack(m_f, dim=1)
         stats['m_p'] = torch.stack(m_p, dim=1)
         stats['P_f_chol'] = torch.stack(P_f_chol, dim=1)


### PR DESCRIPTION
`m_f` — the posterior-mean latent trajectory returned in the `stats` dict — was undocumented. This adds a comment at both `stats['m_f']` assignment sites explaining:
- it is the **filtered** mean when reached via `fast_filter_1_to_T` (local encoder only) vs the **smoothed** mean via `fast_smooth_1_to_T` (adds the backward encoder, conditioning on the whole trial);
- it is **sample-based / stochastic** across calls (`n_samples` trades variance for cost);
- the `m_f` name is legacy filter notation.

Docs-only. This **revives the `m_f`-documentation part of orphaned commit `6dc54c0`** (reviewed and approved by @matthew-dowling in that commit's thread), which was dropped when `smooth()` was removed from #25 — the two were bundled in one commit. The `smooth()`-specific parts are intentionally left out since `smooth()` was not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)